### PR TITLE
Add support for syntax highlighted code blocks

### DIFF
--- a/dmcompile/dmcompile.py
+++ b/dmcompile/dmcompile.py
@@ -97,7 +97,7 @@ class DMCompile(BaseCog):
 
         Use `listbyond` to get a list of BYOND versions you can compile with. 
         """
-        if version == '```':
+        if version.startswith('```'):
             version = "latest"
             code = f"```\n{code}"
         else:


### PR DESCRIPTION
Currently if you do
[p]compile \```c
world.log << "a"
\```
it fails. This PR fixes that.