### PR TITLE
Adds support for the updated topic system

### DIFF
--- a/status/ss13status.py
+++ b/status/ss13status.py
@@ -636,7 +636,7 @@ class SS13Status(commands.Cog):
                         topic_system = await self.config.legacy_topics()
                         status = await self.query_server(server, port, legacy=topic_system)
                     except Exception as e:
-                        error_counter + 1
+                        error_counter = error_counter + 1
                         if error_counter < error_limit:
                             check_time = check_time + 300
                             log.warning(f"There was an error getting the server's status. Attempting again in {check_time}. Error {error_counter} of {error_limit} before disabling checks.\n\nException:\n{e}")

--- a/verifyckey/verifyckey.py
+++ b/verifyckey/verifyckey.py
@@ -12,7 +12,7 @@ import discord
 from discord.ext.commands.errors import CommandInvokeError
 
 #Redbot Imports
-from redbot.core import commands, checks, Config, utils
+from redbot.core import commands, checks, Config
 from redbot.core.utils.chat_formatting import humanize_list
 from redbot.core.utils.predicates import MessagePredicate
 
@@ -377,11 +377,11 @@ class VerifyCkey(commands.Cog):
 
             data = conn.recv(4096) #Minimum number should be 4096, anything less will lose data
 
-            if legacy:
+            if legacy or legacy is None:
                 parsed_data = urllib.parse.parse_qs(data[5:-1].decode())
             else:
                 parsed_data = json.loads(data[5:-1].decode())
-                if data not in parsed_data:
+                if 'data' not in parsed_data:
                     raise LookupError(f"Bad response from server {parsed_data}")
 
             return parsed_data


### PR DESCRIPTION
This is a stop-gap measure to add support for the updated topic system BeeStation uses while still supporting legacy topics.

I am releasing this ahead of a full rewrite of all my major SS13 cogs so that projects using them can continue to do so even if they don't bring over the updated topic API ( https://github.com/BeeStation/BeeStation-Hornet/pull/3801 ). These changes are fairly dirty, but should work without impacting current functionality.

### Note:

By default the cogs will continue to use the legacy topic system. If you port the new API to your project use the `setstatus togglelegacy` and `ckeyauthset togglelegacy` commands to switch over to the updated system.