### PR TITLE
GetNotes cleanup + changes to the "Number of Bans" metric

### DIFF
--- a/getnotes/__init__.py
+++ b/getnotes/__init__.py
@@ -1,4 +1,5 @@
 from .getnotes import GetNotes
 
+
 def setup(bot):
     bot.add_cog(GetNotes(bot))

--- a/getnotes/getnotes.py
+++ b/getnotes/getnotes.py
@@ -636,7 +636,6 @@ class GetNotes(BaseCog):
         conn = await aiomysql.connect(host=db_host, port=db_port, user=db_user, password=db_pass, db=db)
 
         async with conn.cursor(aiomysql.DictCursor) as cur:
-
             await cur.execute(query, (target))
             rows = await cur.fetchall()
 

--- a/getnotes/getnotes.py
+++ b/getnotes/getnotes.py
@@ -293,14 +293,12 @@ class GetNotes(BaseCog):
 
         results = {}
         try:
-            query = query[
-                0
-            ]  # Checks to see if a player was found, if the list is empty nothing was found so we return the empty dict.
+            # Checks to see if a player was found, if the list is empty nothing was found so we return the empty dict.
+            query = query[0]
         except IndexError:
             return None
-        results["ip"] = ipaddress.IPv4Address(
-            query["ip"]
-        )  # IP's are stored as a 32 bit integer, converting it for readability
+            # IP's are stored as a 32 bit integer, converting it for readability
+        results["ip"] = ipaddress.IPv4Address(query["ip"])
         results["cid"] = query["computerid"]
         results["ckey"] = query["ckey"]
         results["first"] = query["firstseen"]

--- a/getnotes/getnotes.py
+++ b/getnotes/getnotes.py
@@ -1,21 +1,21 @@
-#Standard Imports
+# Standard Imports
 import asyncio
-import aiomysql
-import socket
 import ipaddress
-import re
 import logging
+import socket
 from typing import Union
 
-#Discord Imports
+import aiomysql
+
+# Discord Imports
 import discord
 
-#Redbot Imports
-from redbot.core import commands, checks, Config
-from redbot.core.utils.chat_formatting import pagify, box, humanize_list, warning
-from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
+# Redbot Imports
+from redbot.core import Config, checks, commands
+from redbot.core.utils.chat_formatting import box, humanize_list, pagify, warning
+from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 
-#Util Imports
+# Util Imports
 from .util import key_to_ckey
 
 __version__ = "1.2.0"
@@ -24,6 +24,7 @@ __author__ = "Crossedfall"
 log = logging.getLogger("red.SS13GetNotes")
 
 BaseCog = getattr(commands, "Cog", object)
+
 
 class GetNotes(BaseCog):
     def __init__(self, bot):
@@ -38,22 +39,20 @@ class GetNotes(BaseCog):
             "mysql_db": "feedback",
             "mysql_prefix": "",
             "currency_name": "Currency",
-            "admin_ckey": {} #Future thing, not currently used
+            "admin_ckey": {},  # Future thing, not currently used
         }
 
         self.config.register_guild(**default_guild)
         self.loop = asyncio.get_event_loop()
-    
 
     @commands.guild_only()
     @commands.group()
     @checks.admin_or_permissions(administrator=True)
-    async def setnotes(self,ctx): 
+    async def setnotes(self, ctx):
         """
         SS13 MySQL database settings
         """
         pass
-    
 
     @setnotes.command()
     @checks.is_owner()
@@ -65,8 +64,9 @@ class GetNotes(BaseCog):
             await self.config.guild(ctx.guild).mysql_host.set(db_host)
             await ctx.send(f"Database host set to: `{db_host}`")
         except (ValueError, KeyError, AttributeError):
-            await ctx.send("There was an error setting the database's ip/hostname. Please check your entry and try again!")
-    
+            await ctx.send(
+                "There was an error setting the database's ip/hostname. Please check your entry and try again!"
+            )
 
     @setnotes.command()
     @checks.is_owner()
@@ -75,29 +75,29 @@ class GetNotes(BaseCog):
         Sets the MySQL port, defaults to 3306
         """
         try:
-            if 1024 <= db_port <= 65535: # We don't want to allow reserved ports to be set
+            if 1024 <= db_port <= 65535:  # We don't want to allow reserved ports to be set
                 await self.config.guild(ctx.guild).mysql_port.set(db_port)
                 await ctx.send(f"Database port set to: `{db_port}`")
             else:
                 await ctx.send(f"{db_port} is not a valid port!")
         except (ValueError, KeyError, AttributeError):
-            await ctx.send("There was a problem setting your port. Please check to ensure you're attempting to use a port from 1024 to 65535") 
-    
+            await ctx.send(
+                "There was a problem setting your port. Please check to ensure you're attempting to use a port from 1024 to 65535"
+            )
 
-    @setnotes.command(aliases=['name', 'user'])
+    @setnotes.command(aliases=["name", "user"])
     @checks.is_owner()
     async def username(self, ctx, user: str):
         """
         Sets the user that will be used with the MySQL database. Defaults to SS13
 
-        It's recommended to ensure that this user cannot write to the database 
+        It's recommended to ensure that this user cannot write to the database
         """
         try:
             await self.config.guild(ctx.guild).mysql_user.set(user)
             await ctx.send(f"User set to: `{user}`")
         except (ValueError, KeyError, AttributeError):
             await ctx.send("There was a problem setting the username for your database.")
-    
 
     @setnotes.command()
     @checks.is_owner()
@@ -112,11 +112,12 @@ class GetNotes(BaseCog):
             await ctx.send("Your password has been set.")
             try:
                 await ctx.message.delete()
-            except(discord.DiscordException):
-                await ctx.send("I do not have the required permissions to delete messages, please remove/edit the password manually.")
+            except (discord.DiscordException):
+                await ctx.send(
+                    "I do not have the required permissions to delete messages, please remove/edit the password manually."
+                )
         except (ValueError, KeyError, AttributeError):
             await ctx.send("There was a problem setting the password for your database.")
-
 
     @setnotes.command(aliases=["db"])
     @checks.is_owner()
@@ -128,8 +129,7 @@ class GetNotes(BaseCog):
             await self.config.guild(ctx.guild).mysql_db.set(db)
             await ctx.send(f"Database set to: `{db}`")
         except (ValueError, KeyError, AttributeError):
-            await ctx.send ("There was a problem setting your notes database.")
-    
+            await ctx.send("There was a problem setting your notes database.")
 
     @setnotes.command()
     @checks.is_owner()
@@ -142,14 +142,13 @@ class GetNotes(BaseCog):
         try:
             if prefix is None:
                 await self.config.guild(ctx.guild).mysql_prefix.set("")
-                await ctx.send(f"Database prefix removed!")
+                await ctx.send("Database prefix removed!")
             else:
                 await self.config.guild(ctx.guild).mysql_prefix.set(prefix)
                 await ctx.send(f"Database prefix set to: `{prefix}`")
-        
+
         except (ValueError, KeyError, AttributeError):
             await ctx.send("There was a problem setting your database prefix")
-    
 
     @setnotes.command()
     @checks.is_owner()
@@ -162,13 +161,12 @@ class GetNotes(BaseCog):
         try:
             if name is None:
                 await self.config.guild(ctx.guild).currency_name.set("Currency")
-                await ctx.send(f"Metacurrency name reset to `Currency`")
+                await ctx.send("Metacurrency name reset to `Currency`")
             else:
                 await self.config.guild(ctx.guild).currency_name.set(str(name).title())
                 await ctx.send(f"Metacurrency name set to: `{name}`")
         except (ValueError, KeyError, AttributeError):
             await ctx.send("There was a problem setting your currency's name")
-    
 
     @setnotes.command()
     async def current(self, ctx):
@@ -176,17 +174,16 @@ class GetNotes(BaseCog):
         Gets the current settings for the notes database
         """
         settings = await self.config.guild(ctx.guild).all()
-        embed=discord.Embed(title="__Current settings:__")
+        embed = discord.Embed(title="__Current settings:__")
         for k, v in settings.items():
             if k != "admin_ckey":
-                if k != "mysql_password": # Ensures that the database password is not sent
+                if k != "mysql_password":  # Ensures that the database password is not sent
                     if v == "":
                         v = None
-                    embed.add_field(name=f"{k}:",value=v,inline=False)
+                    embed.add_field(name=f"{k}:", value=v, inline=False)
                 else:
-                    embed.add_field(name=f"{k}:",value="`DATA EXPUNGED`",inline=False)
+                    embed.add_field(name=f"{k}:", value="`DATA EXPUNGED`", inline=False)
         await ctx.send(embed=embed)
-
 
     @checks.mod_or_permissions(administrator=True)
     @commands.command()
@@ -195,7 +192,7 @@ class GetNotes(BaseCog):
         Gets the notes for a specific player
         """
         ckey = key_to_ckey(ckey)
-            
+
         prefix = await self.config.guild(ctx.guild).mysql_prefix()
 
         query = f"SELECT timestamp, adminckey, text, type, deleted FROM {prefix}messages WHERE targetckey='{ckey.lower()}' ORDER BY timestamp DESC"
@@ -204,20 +201,20 @@ class GetNotes(BaseCog):
         try:
             rows = await self.query_database(ctx, query)
             if not rows:
-                embed=discord.Embed(description=f"No notes found for: {str(ckey).title()}", color=0xf1d592)
-                return await message.edit(content=None,embed=embed)
+                embed = discord.Embed(description=f"No notes found for: {str(ckey).title()}", color=0xF1D592)
+                return await message.edit(content=None, embed=embed)
             # Parse the data into individual fields within an embeded message in Discord for ease of viewing
             notes = ""
             total = 0
             temp_embeds = []
             embeds = []
             for row in rows:
-                if row['deleted'] == 1:
+                if row["deleted"] == 1:
                     continue
                 total += 1
                 notes += f"\n[{row['timestamp']} | {row['type']} by {row['adminckey']}]\n{row['text']}"
             for note in pagify(notes, ["\n["]):
-                embed = discord.Embed(description=box(note, lang="asciidoc"), color=0xf1d592)
+                embed = discord.Embed(description=box(note, lang="asciidoc"), color=0xF1D592)
                 temp_embeds.append(embed)
             max_i = len(temp_embeds)
             i = 1
@@ -228,25 +225,28 @@ class GetNotes(BaseCog):
                 i += 1
             await message.delete()
             await menu(ctx, embeds, DEFAULT_CONTROLS)
-        
+
         except aiomysql.Error as err:
-            embed=discord.Embed(title=f"Error looking up notes for: {ckey}", description=f"{format(err)}", color=0xff0000)
-            await message.edit(content=None,embed=embed)
-        
+            embed = discord.Embed(
+                title=f"Error looking up notes for: {ckey}", description=f"{format(err)}", color=0xFF0000
+            )
+            await message.edit(content=None, embed=embed)
+
         except ModuleNotFoundError:
-            await message.edit(content="`mysql-connector` requirement not found! Please install this requirement using `pip install mysql-connector`.")
-    
-    
-    async def player_search(self, ctx, ip = None, ckey = None, cid = None) -> dict:
+            await message.edit(
+                content="`mysql-connector` requirement not found! Please install this requirement using `pip install mysql-connector`."
+            )
+
+    async def player_search(self, ctx, ip=None, ckey=None, cid=None) -> dict:
         """
         Runs multiple database queries to obtain the player's information
         """
         prefix = await self.config.guild(ctx.guild).mysql_prefix()
 
         try:
-            # First query is determined by the identifier given 
+            # First query is determined by the identifier given
             if ip:
-                #IPs are stored as a 32 bit integer in the databse. We need to convert it before doing the query.
+                # IPs are stored as a 32 bit integer in the databse. We need to convert it before doing the query.
                 query = f"SELECT ckey, firstseen, lastseen, computerid, ip, accountjoindate FROM {prefix}player WHERE ip='{int(ipaddress.IPv4Address(ip))}'"
                 query = await self.query_database(ctx, query)
             elif ckey:
@@ -258,27 +258,31 @@ class GetNotes(BaseCog):
 
             results = {}
             try:
-                query = query[0] # Checks to see if a player was found, if the list is empty nothing was found so we return the empty dict.
+                query = query[
+                    0
+                ]  # Checks to see if a player was found, if the list is empty nothing was found so we return the empty dict.
             except IndexError:
                 return None
-            results['ip'] = ipaddress.IPv4Address(query['ip']) #IP's are stored as a 32 bit integer, converting it for readability
-            results['cid'] = query['computerid']
-            results['ckey'] = query['ckey']
-            results['first'] = query['firstseen']
-            results['last'] = query['lastseen']
-            results['join'] = query['accountjoindate']
+            results["ip"] = ipaddress.IPv4Address(
+                query["ip"]
+            )  # IP's are stored as a 32 bit integer, converting it for readability
+            results["cid"] = query["computerid"]
+            results["ckey"] = query["ckey"]
+            results["first"] = query["firstseen"]
+            results["last"] = query["lastseen"]
+            results["join"] = query["accountjoindate"]
 
-            #Obtain the number of total connections
+            # Obtain the number of total connections
             query = f"SELECT COUNT(*) FROM {prefix}connection_log WHERE ckey='{results['ckey']}'"
             query = await self.query_database(ctx, query)
-            results['num_connections'] = query[0]['COUNT(*)']
+            results["num_connections"] = query[0]["COUNT(*)"]
 
-            #Obtain the number of total deaths
+            # Obtain the number of total deaths
             query = f"SELECT COUNT(*) FROM {prefix}death WHERE byondkey='{results['ckey']}'"
             query = await self.query_database(ctx, query)
-            results['num_deaths'] = query[0]['COUNT(*)']
+            results["num_deaths"] = query[0]["COUNT(*)"]
 
-            #Obtain role time statistics
+            # Obtain role time statistics
             query = f"SELECT job, minutes FROM {prefix}role_time WHERE ckey='{ckey}' AND (job='Ghost' OR job='Living')"
             try:
                 query = await self.query_database(ctx, query)
@@ -287,66 +291,67 @@ class GetNotes(BaseCog):
 
             if query:
                 for job in query:
-                    if job['job'] == "Living":
-                        results['living_time'] = job['minutes'] // 60
+                    if job["job"] == "Living":
+                        results["living_time"] = job["minutes"] // 60
                     else:
-                        results['ghost_time'] = job['minutes'] // 60
+                        results["ghost_time"] = job["minutes"] // 60
 
-                if 'living_time' not in results.keys():
-                    results['living_time'] = 0
-                if 'ghost_time' not in results.keys():
-                    results['ghost_time'] = 0
+                if "living_time" not in results.keys():
+                    results["living_time"] = 0
+                if "ghost_time" not in results.keys():
+                    results["ghost_time"] = 0
 
             else:
-                results['living_time'] = 0
-                results['ghost_time'] = 0
+                results["living_time"] = 0
+                results["ghost_time"] = 0
 
-            results['total_time'] = results['living_time'] + results['ghost_time']
+            results["total_time"] = results["living_time"] + results["ghost_time"]
 
-            #Obtain metacoins and antag tokens (if avaialble).
+            # Obtain metacoins and antag tokens (if avaialble).
             query = f"SELECT metacoins FROM {prefix}player WHERE ckey='{results['ckey']}'"
             try:
                 query = await self.query_database(ctx, query)
-                results['metacoins'] = (query[0])['metacoins']
+                results["metacoins"] = (query[0])["metacoins"]
             except aiomysql.Error:
                 pass
-            
+
             query = f"SELECT antag_tokens FROM {prefix}player WHERE ckey='{results['ckey']}'"
             try:
                 query = await self.query_database(ctx, query)
-                results['antag_tokens'] = (query[0])['antag_tokens']
+                results["antag_tokens"] = (query[0])["antag_tokens"]
             except aiomysql.Error:
                 pass
 
-            #Obtain the number of bans and, if applicable, the last ban
-            query = f"SELECT bantime FROM {prefix}ban WHERE ckey='{results['ckey']}' ORDER BY bantime DESC"
+            # Obtain the number of bans and, if applicable, the last ban
+            query = (
+                f"SELECT bantime FROM {prefix}ban WHERE ckey='{results['ckey']}' GROUP BY reason ORDER BY bantime DESC"
+            )
             query = await self.query_database(ctx, query)
-            results['num_bans'] = len(query)
-            if results['num_bans'] > 0:
-                results['latest_ban'] = list(query[0].values())[0]
+            results["num_bans"] = len(query)
+            if results["num_bans"] > 0:
+                results["latest_ban"] = list(query[0].values())[0]
             else:
-                results['latest_ban'] = None
+                results["latest_ban"] = None
 
-            #Obtain the total number of notes
+            # Obtain the total number of notes
             query = f"SELECT COUNT(*) FROM {prefix}messages WHERE targetckey='{results['ckey']}'"
             query = await self.query_database(ctx, query)
-            results['notes'] = query[0]['COUNT(*)']
+            results["notes"] = query[0]["COUNT(*)"]
 
             # Notes/Deaths per hour
-            if results['living_time'] > 0:
-                results['notes_per_hour'] = round(results['notes'] / (results['total_time']), 3)
-                results['deaths_per_hour'] = round(results['num_deaths'] / (results['living_time']), 2)
+            if results["living_time"] > 0:
+                results["notes_per_hour"] = round(results["notes"] / (results["total_time"]), 3)
+                results["deaths_per_hour"] = round(results["num_deaths"] / (results["living_time"]), 2)
             else:
-                results['notes_per_hour'] = 0
-                results['deaths_per_hour'] = 0
+                results["notes_per_hour"] = 0
+                results["deaths_per_hour"] = 0
 
             return results
 
         except:
             raise
 
-
-    @commands.command(aliases=['ckey'])
+    @commands.command(aliases=["ckey"])
     async def playerinfo(self, ctx, *, ckey: str):
         """
         Lookup a player's stats based on their ckey
@@ -356,33 +361,38 @@ class GetNotes(BaseCog):
         try:
             message = await ctx.send("Looking up player....")
             async with ctx.typing():
-                embed=discord.Embed(color=await ctx.embed_color())
+                embed = discord.Embed(color=await ctx.embed_color())
                 embed.set_author(name=f"Player info for {str(ckey).title()}")
                 player = await self.player_search(ctx, ckey=ckey)
-            
+
             if player is None:
                 raise ValueError
-            
+
             player_stats = f"**Playtime**: {player['total_time']}h ({player['living_time']}h/{player['ghost_time']}h)\n**Deaths per Hour**: {player['deaths_per_hour']}"
-            if 'metacoins' in player.keys():
+            if "metacoins" in player.keys():
                 player_stats += f"\n**{await self.config.guild(ctx.guild).currency_name()}**: {player['metacoins']}"
-            if 'antag_tokens' in player.keys():
+            if "antag_tokens" in player.keys():
                 player_stats += f"\n**Antag Tokens**: {player['antag_tokens']}"
 
             embed.add_field(name="__Player Statistics__:", value=player_stats, inline=False)
-            embed.add_field(name="__Connection Information:__", value=f"**First Seen**: {player['first']}\n**Last Seen**: {player['last']}\n**Account Join Date**: {player['join']}\n**Number of Connections**: {player['num_connections']}", inline=False)
+            embed.add_field(
+                name="__Connection Information:__",
+                value=f"**First Seen**: {player['first']}\n**Last Seen**: {player['last']}\n**Account Join Date**: {player['join']}\n**Number of Connections**: {player['num_connections']}",
+                inline=False,
+            )
             await message.edit(content=None, embed=embed)
 
         except ValueError:
             return await message.edit(content="No results found.")
-        
-        except aiomysql.Error  as err:
-            embed=discord.Embed(title=f"Error looking up player", description=f"{format(err)}", color=0xff0000)
-            return await message.edit(content=None,embed=embed)
-            
-        except ModuleNotFoundError:
-            return await message.edit(content="`mysql-connector` requirement not found! Please install this requirement using `pip install mysql-connector`.")
 
+        except aiomysql.Error as err:
+            embed = discord.Embed(title="Error looking up player", description=f"{format(err)}", color=0xFF0000)
+            return await message.edit(content=None, embed=embed)
+
+        except ModuleNotFoundError:
+            return await message.edit(
+                content="`mysql-connector` requirement not found! Please install this requirement using `pip install mysql-connector`."
+            )
 
     @checks.mod_or_permissions(administrator=True)
     @commands.command()
@@ -390,7 +400,7 @@ class GetNotes(BaseCog):
         """
         Obtains information about a specific player.
 
-        Will search for players using a provided IP, CID, or CKEY. 
+        Will search for players using a provided IP, CID, or CKEY.
         """
 
         try:
@@ -405,54 +415,75 @@ class GetNotes(BaseCog):
                     identifier = key_to_ckey(identifier)
                     player = await self.player_search(ctx, ckey=identifier)
                 else:
-                    return await message.edit(content="That doesn't look like an IP, CID, or CKEY. Please check your entry and try again!")
-                    
+                    return await message.edit(
+                        content="That doesn't look like an IP, CID, or CKEY. Please check your entry and try again!"
+                    )
+
             if player is None:
                 raise ValueError
-                
-            embed=discord.Embed(color=await ctx.embed_color())
+
+            embed = discord.Embed(color=await ctx.embed_color())
             embed.set_author(name=f"Player info for {str(player['ckey']).title()}")
 
             player_stats = f"**Playtime**: {player['total_time']}h ({player['living_time']}h/{player['ghost_time']}h)\n**Deaths per Hour**: {player['deaths_per_hour']}"
-            if 'metacoins' in player.keys():
+            if "metacoins" in player.keys():
                 player_stats += f"\n**{await self.config.guild(ctx.guild).currency_name()}**: {player['metacoins']}"
-            if 'antag_tokens' in player.keys():
+            if "antag_tokens" in player.keys():
                 player_stats += f"\n**Antag Tokens**: {player['antag_tokens']}"
-            
-            embed.add_field(name="__Identity:__",value=f"**CKEY**: {player['ckey']}\n**CID**: {player['cid']}\n**IP**: {player['ip']}\n**Account Join Date**: {player['join']}", inline=False)                    
+
+            embed.add_field(
+                name="__Identity:__",
+                value=f"**CKEY**: {player['ckey']}\n**CID**: {player['cid']}\n**IP**: {player['ip']}\n**Account Join Date**: {player['join']}",
+                inline=False,
+            )
             embed.add_field(name="__Player Statistics__:", value=player_stats, inline=False)
-            embed.add_field(name="__Connection Information:__", value=f"**First Seen**: {player['first']}\n**Last Seen**: {player['last']}\n**Number of Connections**: {player['num_connections']}", inline=False)
-    
-            embed.add_field(name="__Bans/Notes:__", value=f"**Number of Notes**: {player['notes']}\n**Number of Bans**: {player['num_bans']}\n**Last Ban**: {player['latest_ban']}\n**Notes per Hour**: {player['notes_per_hour']}", inline=False)
+            embed.add_field(
+                name="__Connection Information:__",
+                value=f"**First Seen**: {player['first']}\n**Last Seen**: {player['last']}\n**Number of Connections**: {player['num_connections']}",
+                inline=False,
+            )
+
+            embed.add_field(
+                name="__Bans/Notes:__",
+                value=f"**Number of Notes**: {player['notes']}\n**Number of Bans**: {player['num_bans']}\n**Last Ban**: {player['latest_ban']}\n**Notes per Hour**: {player['notes_per_hour']}",
+                inline=False,
+            )
 
             await message.edit(content=None, embed=embed)
 
             # After 5-minutes redact the player's CID and IP.
             await asyncio.sleep(300)
-            embed.set_field_at(0, name="__Identity:__",value=f"**CKEY**: {player['ckey']}\n**CID**: `[DATA EXPUNGED]`\n**IP**: `[DATA EXPUNGED]`\n**Account Join Date**: {player['join']}", inline=False)                    
+            embed.set_field_at(
+                0,
+                name="__Identity:__",
+                value=f"**CKEY**: {player['ckey']}\n**CID**: `[DATA EXPUNGED]`\n**IP**: `[DATA EXPUNGED]`\n**Account Join Date**: {player['join']}",
+                inline=False,
+            )
 
             await message.edit(content=None, embed=embed)
 
         except ValueError:
             return await message.edit(content="No results found.")
-        
+
         except (aiomysql.Error, ValueError) as err:
-            embed=discord.Embed(title=f"Error looking up player", description=f"{format(err)}", color=0xff0000)
-            return await message.edit(content=None,embed=embed)
-            
+            embed = discord.Embed(title="Error looking up player", description=f"{format(err)}", color=0xFF0000)
+            return await message.edit(content=None, embed=embed)
+
         except ModuleNotFoundError:
-            return await message.edit(content="`mysql-connector` requirement not found! Please install this requirement using `pip install mysql-connector`.")
-    
+            return await message.edit(
+                content="`mysql-connector` requirement not found! Please install this requirement using `pip install mysql-connector`."
+            )
+
     @checks.mod()
     @commands.command()
-    async def alts(self, ctx, ckey:str, check_ips:bool = True):
+    async def alts(self, ctx, ckey: str, check_ips: bool = True):
         """
         Search for a list of possible alt accounts
 
         This command can take a long time if there are a lot of alt accounts or if your connections table is very large!
         """
         try:
-            if check_ips == False:
+            if check_ips is False:
                 await ctx.send(f"{warning('IP check bypassed')}")
             message = await ctx.send("Checking for alts...")
             async with ctx.typing():
@@ -463,26 +494,27 @@ class GetNotes(BaseCog):
                         await ctx.send(f"Possible alts for {ckey}:\n> {alts}")
                     else:
                         await ctx.send(f"Possible alts for {ckey}:")
-                        for page in pagify(alts, delims=[' ']):
+                        for page in pagify(alts, delims=[" "]):
                             await ctx.send(f"> {page}")
                 else:
                     await ctx.send("No alts detected!")
-                await message.delete() #Deleting over editing since this command can take a while
+                await message.delete()  # Deleting over editing since this command can take a while
 
-        except aiomysql.Error  as err:
-            embed=discord.Embed(title=f"Error looking up alts", description=f"{format(err)}", color=0xff0000)
+        except aiomysql.Error as err:
+            embed = discord.Embed(title="Error looking up alts", description=f"{format(err)}", color=0xFF0000)
             await ctx.send(embed=embed)
-            return await message.delete() #^
-        
+            return await message.delete()  # ^
+
         except RuntimeError:
-            embed=discord.Embed(title=f"Error looking up alts", description="Please check your entry and try again!", color=0xff0000)
+            embed = discord.Embed(
+                title="Error looking up alts", description="Please check your entry and try again!", color=0xFF0000
+            )
             await ctx.send(embed=embed)
-            return await message.delete() #^
+            return await message.delete()  # ^
 
-
-    async def get_alts(self, ctx, target:str, check_ips:bool) -> list:
+    async def get_alts(self, ctx, target: str, check_ips: bool) -> list:
         """Performs a comprehensive check of the database for possible alt accounts"""
-        #Credit for the original code goes to Qwerty (https://github.com/qwertyquerty)
+        # Credit for the original code goes to Qwerty (https://github.com/qwertyquerty)
         try:
             prefix = await self.config.guild(ctx.guild).mysql_prefix()
             caught_alts = []
@@ -496,32 +528,45 @@ class GetNotes(BaseCog):
                 linked = []
 
                 if investigating[1] == "ckey":
-                    linked = await self.query_database(ctx, f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE ckey='{investigating[0]}'")
+                    linked = await self.query_database(
+                        ctx, f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE ckey='{investigating[0]}'"
+                    )
                 if investigating[1] == "computerid":
-                    linked = await self.query_database(ctx, f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE computerid='{investigating[0]}'")
+                    linked = await self.query_database(
+                        ctx,
+                        f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE computerid='{investigating[0]}'",
+                    )
                 if investigating[1] == "ip" and check_ips is True:
-                    linked = await self.query_database(ctx, f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE ip='{investigating[0]}'")
-                
+                    linked = await self.query_database(
+                        ctx, f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE ip='{investigating[0]}'"
+                    )
+
                 investigated.append(investigating)
 
                 for link in linked:
-                    if (link['ckey'], "ckey") not in investigated and (link['ckey'], "ckey") not in to_investigate:
-                        to_investigate.append((link['ckey'], "ckey"))
+                    if (link["ckey"], "ckey") not in investigated and (link["ckey"], "ckey") not in to_investigate:
+                        to_investigate.append((link["ckey"], "ckey"))
 
-                        if link['ckey'] not in caught_alts:
-                            caught_alts.append(link['ckey'])
+                        if link["ckey"] not in caught_alts:
+                            caught_alts.append(link["ckey"])
 
-                    if (link['computerid'], "computerid") not in investigated and (link['computerid'], "computerid") not in to_investigate:
-                        to_investigate.append((link['computerid'], "computerid"))
+                    if (link["computerid"], "computerid") not in investigated and (
+                        link["computerid"],
+                        "computerid",
+                    ) not in to_investigate:
+                        to_investigate.append((link["computerid"], "computerid"))
 
-                    if (link['ip'], "ip") not in investigated and (link['ip'], "ip") not in to_investigate and check_ips is True:
-                        to_investigate.append((link['ip'], "ip"))
+                    if (
+                        (link["ip"], "ip") not in investigated
+                        and (link["ip"], "ip") not in to_investigate
+                        and check_ips is True
+                    ):
+                        to_investigate.append((link["ip"], "ip"))
 
             return caught_alts
 
         except RuntimeError:
             raise
-
 
     async def query_database(self, ctx, query: str):
         # Database options loaded from the config
@@ -531,19 +576,21 @@ class GetNotes(BaseCog):
         db_user = await self.config.guild(ctx.guild).mysql_user()
         db_pass = await self.config.guild(ctx.guild).mysql_password()
 
-        pool = None # Since the pool variables can't actually be closed if the connection isn't properly established we set a None type here
+        pool = None  # Since the pool variables can't actually be closed if the connection isn't properly established we set a None type here
 
         try:
             # Establish a connection with the database and pull the relevant data
-            pool = await aiomysql.create_pool(host=db_host,port=db_port,db=db,user=db_user,password=db_pass, connect_timeout=5)
+            pool = await aiomysql.create_pool(
+                host=db_host, port=db_port, db=db, user=db_user, password=db_pass, connect_timeout=5
+            )
             async with pool.acquire() as conn:
                 async with conn.cursor(aiomysql.DictCursor) as cur:
                     await cur.execute(query)
                     rows = cur.fetchall()
                     return rows.result()
-            
+
         except:
-            raise 
+            raise
 
         finally:
             if pool is not None:

--- a/getnotes/getnotes.py
+++ b/getnotes/getnotes.py
@@ -68,12 +68,12 @@ class GetNotes(BaseCog):
             await self.bot.send_to_owners(
                 "⚠__Important Change to the GetNotes Cog__⚠\n\n"
                 'The "Number of Bans" metric has changed! Previously, this number would be a tally of **ALL** bans. '
-                "In effect, this would mean that job bans would be tallied seperately instead of grouped together as a single ban. "
+                "In effect, this would mean that mass job bans would be tallied per job instead of grouped together as a single ban. "
                 "This lead to an inflated sum and a potentially misleading summary of the player. "
-                "For example, a player with a full antag role ban and one (1) server ban would have 25 bans reported. 24 individual role bans and the one (1) server ban.\n\n"
+                "For example, banning a player from all antag roles at once would result in the cog listing 24 bans instead of just a single ban.\n\n"
                 "Moving forward, bans will be grouped by when they were issued. "
-                "This means that if an admin were to issue several role bans at once, they would all be reported as a single ban. "
-                "For the previous example, using `findplayer` against the same target would now report two (2) bans instead of 25. "
+                "This means that if an admin were to issue several role bans at once, they will now be reported as a single ban by GetNotes. "
+                "For the previous example, using `findplayer` against the same target would now report one (1) ban instead of 24 bans. "
             )
 
         await self.config.config_version.set(__version__)

--- a/getnotes/info.json
+++ b/getnotes/info.json
@@ -1,5 +1,7 @@
 {
-    "author": ["Crossedfall (Crossedfall#1001)"],
+    "author": [
+        "Crossedfall (Crossedfall#1001)"
+    ],
     "install_msg": "Thank you for installing getnotes! Please note that the `setnotesdatabase` commands are owner only\nsee the [readme](https://github.com/crossedfall/crossed-cogs#getnotes) for detailed setup instructions.",
     "name": "SS13 Notes Helper",
     "short": "Obtains player notes and posts them into discord on command!",
@@ -7,7 +9,10 @@
         "aiomysql>=0.0.20"
     ],
     "description": "Pulls player notes from your database. TG Scheme required",
-    "permissions" : ["Manage Messages", "Embed Links"],
+    "permissions": [
+        "Manage Messages",
+        "Embed Links"
+    ],
     "tags": [
         "Space Station 13",
         "Game",

--- a/getnotes/util.py
+++ b/getnotes/util.py
@@ -1,4 +1,5 @@
 import re
 
+
 def key_to_ckey(key):
-	return re.sub('[^A-Za-z0-9]+', '', key)
+    return re.sub("[^A-Za-z0-9]+", "", key)


### PR DESCRIPTION
This PR does three things.

1. Cleans up a large portion of the GetNotes cog's code to make it significantly more readable
2. Reverts the database pooling since that didn't do anything but create more of a headache.
    - The alts command is still a mess and needs a significant rework
3. Changes how the "Number of Bans" metric is calculated. 

---

The first change doesn't need much explaining, so I'll skip over that. It's mostly pep8 compliance and black formatting.

For two, in addition to changing how database queries are executed, this also changes how the queries are processed by the library. Originally, I was relying on the module's ability to sanitize strings, but that was honestly a bit foolish. This method did little to combat potential changes to the dependency or to account for the use of a different dependency altogether.  To rectify this, user-provided (non-config) variables will be parsed and escaped by the library according to better practices. **Database owners should still ensure that the user given to the bot does not have the ability to make lasting changes to the database.**

Finally, the `num_bans` variable calculation has been adjusted based on user feedback. Previously, this number would be a tally of **ALL** bans listed in the database. In effect, this would mean that mass job bans would be tallied _per job_ instead of grouped together as a single ban. This lead to an inflated sum and a potentially misleading summary of the player. For example, banning a player from all antag roles at once would result in the cog listing 24 bans instead of just a single ban.

Moving forward, bans will be grouped by when they were issued. This means that if an admin were to issue several role bans at once, they will now be reported as a single ban by GetNotes. For the previous example, using findplayer against the same target would now report one (1) ban instead of 24 bans.