### PR TITLE
[GetNotes] Remove some try/except clauses to let more runtimes though

### DIFF
--- a/getnotes/getnotes.py
+++ b/getnotes/getnotes.py
@@ -555,73 +555,62 @@ class GetNotes(BaseCog):
             await ctx.send(embed=embed)
             return await message.delete()  # ^
 
-        except RuntimeError:
-            embed = discord.Embed(
-                title="Error looking up alts", description="Please check your entry and try again!", color=0xFF0000
-            )
-            await ctx.send(embed=embed)
-            return await message.delete()  # ^
-
     async def get_alts(self, ctx, target: str, check_ips: bool) -> list:
         """Performs a comprehensive check of the database for possible alt accounts"""
         # Credit for the original code goes to Qwerty (https://github.com/qwertyquerty)
-        try:
-            prefix = await self.config.guild(ctx.guild).mysql_prefix()
-            caught_alts = []
-            investigated = []
-            to_investigate = [(target, "ckey")]
+        prefix = await self.config.guild(ctx.guild).mysql_prefix()
+        caught_alts = []
+        investigated = []
+        to_investigate = [(target, "ckey")]
 
-            while len(to_investigate) > 0:
-                investigating = to_investigate.pop(len(to_investigate) - 1)
-                log.debug(f"Investigating: {investigating} :: Number to check: {len(to_investigate)}")
+        while len(to_investigate) > 0:
+            investigating = to_investigate.pop(len(to_investigate) - 1)
+            log.debug(f"Investigating: {investigating} :: Number to check: {len(to_investigate)}")
 
-                linked = []
+            linked = []
 
-                if investigating[1] == "ckey":
-                    linked = await self.query_database(
-                        ctx.guild,
-                        f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE ckey=%s",
-                        investigating[0],
-                    )
-                if investigating[1] == "computerid":
-                    linked = await self.query_database(
-                        ctx.guild,
-                        f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE computerid=%s",
-                        investigating[0],
-                    )
-                if investigating[1] == "ip" and check_ips is True:
-                    linked = await self.query_database(
-                        ctx.guild,
-                        f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE ip=%s",
-                        investigating[0],
-                    )
+            if investigating[1] == "ckey":
+                linked = await self.query_database(
+                    ctx.guild,
+                    f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE ckey=%s",
+                    investigating[0],
+                )
+            if investigating[1] == "computerid":
+                linked = await self.query_database(
+                    ctx.guild,
+                    f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE computerid=%s",
+                    investigating[0],
+                )
+            if investigating[1] == "ip" and check_ips is True:
+                linked = await self.query_database(
+                    ctx.guild,
+                    f"SELECT ckey, ip, computerid FROM {prefix}connection_log WHERE ip=%s",
+                    investigating[0],
+                )
 
-                investigated.append(investigating)
+            investigated.append(investigating)
 
-                for link in linked:
-                    if (link["ckey"], "ckey") not in investigated and (link["ckey"], "ckey") not in to_investigate:
-                        to_investigate.append((link["ckey"], "ckey"))
+            for link in linked:
+                if (link["ckey"], "ckey") not in investigated and (link["ckey"], "ckey") not in to_investigate:
+                    to_investigate.append((link["ckey"], "ckey"))
 
-                        if link["ckey"] not in caught_alts:
-                            caught_alts.append(link["ckey"])
+                    if link["ckey"] not in caught_alts:
+                        caught_alts.append(link["ckey"])
 
-                    if (link["computerid"], "computerid") not in investigated and (
-                        link["computerid"],
-                        "computerid",
-                    ) not in to_investigate:
-                        to_investigate.append((link["computerid"], "computerid"))
+                if (link["computerid"], "computerid") not in investigated and (
+                    link["computerid"],
+                    "computerid",
+                ) not in to_investigate:
+                    to_investigate.append((link["computerid"], "computerid"))
 
-                    if (
-                        (link["ip"], "ip") not in investigated
-                        and (link["ip"], "ip") not in to_investigate
-                        and check_ips is True
-                    ):
-                        to_investigate.append((link["ip"], "ip"))
+                if (
+                    (link["ip"], "ip") not in investigated
+                    and (link["ip"], "ip") not in to_investigate
+                    and check_ips is True
+                ):
+                    to_investigate.append((link["ip"], "ip"))
 
-            return caught_alts
-
-        except RuntimeError:
-            raise
+        return caught_alts
 
     async def query_database(self, guild: discord.Guild, query: str, target: str):
         # Database options loaded from the config


### PR DESCRIPTION
The current set of try/except clauses around the alts command causes silent failures and makes it difficult to improve. This wont fix any problems, but at least it should mask them anymore.