### PR TITLE
Adds ban notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,18 @@ In order to process the new config option, the following entry must be added to 
 /datum/config_entry/string/bot_ip
 ```
 
-
+In order to use ban notice option, following has to be added to the code/modules/admin/sql_ban_system.dm:
+```
+SSredbot.send_discord_message("ban", "[kn] [msg][roles_to_ban[1] == "Server" ? "" : " Roles: [roles_to_ban.Join("\n")]"]\nReason: [reason]", "ticket")
+```
+Example:
+```
+var/msg = "has created a [isnull(duration) ? "permanent" : "temporary [time_message]"] [applies_to_admins ? "admin " : ""][roles_to_ban[1] == "Server" ? "server ban" : "role ban from [roles_to_ban.len] roles"] for [target]."
+	log_admin_private("[kn] [msg][roles_to_ban[1] == "Server" ? "" : " Roles: [roles_to_ban.Join(", ")]"] Reason: [reason]")
+	message_admins("[kna] [msg][roles_to_ban[1] == "Server" ? "" : " Roles: [roles_to_ban.Join("\n")]"]\nReason: [reason]")
+	SSredbot.send_discord_message("ban", "[kna] [msg][roles_to_ban[1] == "Server" ? "" : " Roles: [roles_to_ban.Join("\n")]"]\nReason: [reason]", "ticket")
+	SSredbot.send_discord_message("ban", "[kn] [msg][roles_to_ban[1] == "Server" ? "" : " Roles: [roles_to_ban.Join("\n")]"]\nReason: [reason]", "ticket")
+```
 
 #### Usage:
 

--- a/status/ss13status.py
+++ b/status/ss13status.py
@@ -580,7 +580,7 @@ class SS13Status(commands.Cog):
                     embed.set_footer(text=f"Round: {self.roundID}")
                 await mentor_channel.send(embed=embed)
 
-            elif ('announce_channel' in parsed_data) and ('ban' in parsed_data['announce_channel']) and (ban_channel is not None): #shitty copypaste cause I dunno what am doing
+            elif ('announce_channel' in parsed_data) and ('ban' in parsed_data['announce_channel']) and (ban_channel is not None): #sends notice to configured channel when user gets banned
                 announce = str(*parsed_data['announce'])
                 embed = discord.Embed(title=f"Ban Notice", description=announce, color=0xff0000)
                 if self.roundID is not None:

--- a/status/ss13status.py
+++ b/status/ss13status.py
@@ -3,7 +3,7 @@ import asyncio
 import struct
 import socket
 import urllib.parse
-import html.parser as htmlparser
+import html as htmlparser
 import time
 import textwrap
 from datetime import datetime

--- a/status/ss13status.py
+++ b/status/ss13status.py
@@ -41,7 +41,6 @@ class SS13Status(commands.Cog):
             "new_round_channel": None,
             "admin_notice_channel": None,
             "mentor_notice_channel": None,
-            "ban_notice_channel": None,
             "mention_role": None,
             "comms_key": "default_pwd",
             "listen_port": 8081,
@@ -174,23 +173,6 @@ class SS13Status(commands.Cog):
         except(ValueError, KeyError, AttributeError):
             await ctx.send("There was a problem setting the notification channel. Please check your entry and try again.")
 
-    async def banchannel(self, ctx, text_channel: discord.TextChannel = None):
-        """
-        Set the text channel for ban notifications.
-        
-        Use without providing a channel to reset this to None.
-        """
-        try:
-            if text_channel is not None:
-                await self.config.ban_notice_channel.set(text_channel.id)
-                await ctx.send(f"Ban notifications will be sent to: {text_channel.mention}")
-            else:
-                await self.config.ban_notice_channel.set(None)
-                await ctx.send("I will no longer provide ban notices.")
-
-        except(ValueError, KeyError, AttributeError):
-            await ctx.send("There was a problem setting the notification channel. Please check your entry and try again.")
-
     @setstatus.command()
     async def mentionrole(self, ctx, role: discord.Role = None):
         """
@@ -290,7 +272,7 @@ class SS13Status(commands.Cog):
         for k, v in settings.items():
             if k == 'comms_key': #We don't want to actively display the comms key
                 embed.add_field(name=f"{k}:", value="`redacted`", inline=False)
-            elif (k == 'new_round_channel' or k == 'admin_notice_channel' or k == 'mentor_notice_channel' or k == 'ban_notice_channel') and (v is not None): #Linkify channels
+            elif (k == 'new_round_channel' or k == 'admin_notice_channel' or k == 'mentor_notice_channel') and (v is not None): #Linkify channels
                 embed.add_field(name=f"{k}:", value=f"<#{v}>", inline=False)
             elif k == 'mention_role':
                 role = discord.utils.get(ctx.guild.roles, id=await self.config.mention_role())
@@ -521,7 +503,6 @@ class SS13Status(commands.Cog):
         ##################
         admin_channel = self.bot.get_channel(await self.config.admin_notice_channel())
         mentor_channel = self.bot.get_channel(await self.config.mentor_notice_channel())
-        ban_channel = self.bot.get_channel(await self.config.ban_notice_channel())
         new_round_channel = self.bot.get_channel(await self.config.new_round_channel())
         if admin_channel is not None:
             mention_role = discord.utils.get(admin_channel.guild.roles, id=(await self.config.mention_role()))
@@ -578,15 +559,6 @@ class SS13Status(commands.Cog):
                 if self.roundID is not None:
                     embed.set_footer(text=f"Round: {self.roundID}")
                 await mentor_channel.send(embed=embed)
-
-            elif ('announce_channel' in parsed_data) and ('ban' in parsed_data['announce_channel']) and (ban_channel is not None): #shitty copypaste cause I dunno what am doing
-                announce = str(*parsed_data['announce'])
-                ticket = announce.split('): ')
-                ticket[1] = parser.unescape(ticket[1])
-                embed = discord.Embed(title=f"{ticket[0]}):", description=ticket[1], color=0xff0000)
-                if self.roundID is not None:
-                    embed.set_footer(text=f"Round: {self.roundID}")
-                await ban_channel.send(embed=embed)
 
             elif ('announce_channel' in parsed_data) and ('admin' in parsed_data['announce_channel']) and (admin_channel is not None): #Secret messages only meant for admin eyes
                 announce = str(*parsed_data['announce'])

--- a/status/ss13status.py
+++ b/status/ss13status.py
@@ -528,7 +528,7 @@ class SS13Status(commands.Cog):
             mention_role = discord.utils.get(admin_channel.guild.roles, id=(await self.config.mention_role()))
         comms_key = await self.config.comms_key()
         byondurl = await self.config.server_url()
-        parser = htmlparser.HTMLParser()
+        parser = htmlparser
 
         log.debug("Message incoming!")
 

--- a/status/ss13status.py
+++ b/status/ss13status.py
@@ -582,9 +582,7 @@ class SS13Status(commands.Cog):
 
             elif ('announce_channel' in parsed_data) and ('ban' in parsed_data['announce_channel']) and (ban_channel is not None): #shitty copypaste cause I dunno what am doing
                 announce = str(*parsed_data['announce'])
-                ticket = announce.split('): ')
-                ticket[1] = parser.unescape(ticket[1])
-                embed = discord.Embed(title=f"{ticket[0]}):", description=ticket[1], color=0xff0000)
+                embed = discord.Embed(title=f"Ban Notice", description=announce, color=0xff0000)
                 if self.roundID is not None:
                     embed.set_footer(text=f"Round: {self.roundID}")
                 await ban_channel.send(embed=embed)

--- a/status/ss13status.py
+++ b/status/ss13status.py
@@ -41,6 +41,7 @@ class SS13Status(commands.Cog):
             "new_round_channel": None,
             "admin_notice_channel": None,
             "mentor_notice_channel": None,
+            "ban_notice_channel": None,
             "mention_role": None,
             "comms_key": "default_pwd",
             "listen_port": 8081,
@@ -173,6 +174,23 @@ class SS13Status(commands.Cog):
         except(ValueError, KeyError, AttributeError):
             await ctx.send("There was a problem setting the notification channel. Please check your entry and try again.")
 
+    async def banchannel(self, ctx, text_channel: discord.TextChannel = None):
+        """
+        Set the text channel for ban notifications.
+        
+        Use without providing a channel to reset this to None.
+        """
+        try:
+            if text_channel is not None:
+                await self.config.ban_notice_channel.set(text_channel.id)
+                await ctx.send(f"Ban notifications will be sent to: {text_channel.mention}")
+            else:
+                await self.config.ban_notice_channel.set(None)
+                await ctx.send("I will no longer provide ban notices.")
+
+        except(ValueError, KeyError, AttributeError):
+            await ctx.send("There was a problem setting the notification channel. Please check your entry and try again.")
+
     @setstatus.command()
     async def mentionrole(self, ctx, role: discord.Role = None):
         """
@@ -272,7 +290,7 @@ class SS13Status(commands.Cog):
         for k, v in settings.items():
             if k == 'comms_key': #We don't want to actively display the comms key
                 embed.add_field(name=f"{k}:", value="`redacted`", inline=False)
-            elif (k == 'new_round_channel' or k == 'admin_notice_channel' or k == 'mentor_notice_channel') and (v is not None): #Linkify channels
+            elif (k == 'new_round_channel' or k == 'admin_notice_channel' or k == 'mentor_notice_channel' or k == 'ban_notice_channel') and (v is not None): #Linkify channels
                 embed.add_field(name=f"{k}:", value=f"<#{v}>", inline=False)
             elif k == 'mention_role':
                 role = discord.utils.get(ctx.guild.roles, id=await self.config.mention_role())
@@ -503,6 +521,7 @@ class SS13Status(commands.Cog):
         ##################
         admin_channel = self.bot.get_channel(await self.config.admin_notice_channel())
         mentor_channel = self.bot.get_channel(await self.config.mentor_notice_channel())
+        ban_channel = self.bot.get_channel(await self.config.ban_notice_channel())
         new_round_channel = self.bot.get_channel(await self.config.new_round_channel())
         if admin_channel is not None:
             mention_role = discord.utils.get(admin_channel.guild.roles, id=(await self.config.mention_role()))
@@ -559,6 +578,15 @@ class SS13Status(commands.Cog):
                 if self.roundID is not None:
                     embed.set_footer(text=f"Round: {self.roundID}")
                 await mentor_channel.send(embed=embed)
+
+            elif ('announce_channel' in parsed_data) and ('ban' in parsed_data['announce_channel']) and (ban_channel is not None): #shitty copypaste cause I dunno what am doing
+                announce = str(*parsed_data['announce'])
+                ticket = announce.split('): ')
+                ticket[1] = parser.unescape(ticket[1])
+                embed = discord.Embed(title=f"{ticket[0]}):", description=ticket[1], color=0xff0000)
+                if self.roundID is not None:
+                    embed.set_footer(text=f"Round: {self.roundID}")
+                await ban_channel.send(embed=embed)
 
             elif ('announce_channel' in parsed_data) and ('admin' in parsed_data['announce_channel']) and (admin_channel is not None): #Secret messages only meant for admin eyes
                 announce = str(*parsed_data['announce'])

--- a/status/ss13status.py
+++ b/status/ss13status.py
@@ -174,6 +174,7 @@ class SS13Status(commands.Cog):
         except(ValueError, KeyError, AttributeError):
             await ctx.send("There was a problem setting the notification channel. Please check your entry and try again.")
 
+    @setstatus.command()
     async def banchannel(self, ctx, text_channel: discord.TextChannel = None):
         """
         Set the text channel for ban notifications.


### PR DESCRIPTION
I am very grateful for the cogs you have made. I had to change parser due to html.parser being scrapped and added separate category for sending notices on user getting banned. The message sent is straight up the same content as in game admin log.

Example:
![obraz](https://user-images.githubusercontent.com/79363897/155337380-b87b3c73-658b-424d-bed7-45c39d855233.png)
