### PR TITLE
Some Goonstation improvements(?)

### DIFF
--- a/dmcompile/dmcompile.py
+++ b/dmcompile/dmcompile.py
@@ -66,7 +66,7 @@ class DMCompile(BaseCog):
         """
         Set the default version of BYOND used
 
-        Should be similar to: 514.1549
+        Should be in format similar to: 514.1589
         """
 
         try:

--- a/dmcompile/dmcompile.py
+++ b/dmcompile/dmcompile.py
@@ -74,21 +74,6 @@ class DMCompile(BaseCog):
             await ctx.send(f"Default version set to: {version}")
         except (ValueError, KeyError, AttributeError):
             await ctx.send("There was an error setting the default version. Please check your entry and try again.")
-    
-    @commands.command()
-    async def listbyond(self, ctx):
-        """
-        List the available BYOND versions
-
-        List generated from the beestation/byond docker repository.
-
-        _This command also updates the internal list of available versions for the compiler._
-        """
-
-        repo_tags = await self.version_list()
-        repo_tags.remove("latest")
-        
-        await ctx.send(f"The currently available BYOND versions are:\n> {chat_formatting.humanize_list(repo_tags)}")
 
     @commands.command(usage="[version] <code>")
     async def compile(self, ctx, *, code:str):

--- a/dmcompile/dmcompile.py
+++ b/dmcompile/dmcompile.py
@@ -33,7 +33,7 @@ class DMCompile(BaseCog):
 
         default_config = {
             "listener_url": "http://localhost:5000/compile",
-            "default_version": "514.1549"
+            "default_version": "514.1589"
         }
 
         self.config.register_global(**default_config)

--- a/dmcompile/dmcompile.py
+++ b/dmcompile/dmcompile.py
@@ -153,13 +153,10 @@ class DMCompile(BaseCog):
             errors = ERROR_PATTERN.search(compile_log)
             warnings = WARNING_PATTERN.search(compile_log)
             if int(errors.group(1)) > 0:
-                if tiny_output:
-                    await ctx.send("Compile error. Maybe you meant to use \\`\\`\\` instead of \\`?")
-                    return await message.delete()
-                else:
-                    embed = discord.Embed(title="Compilation failed!", description=f"Compiler output:\n{box(escape(compile_log, mass_mentions=True, formatting=True))}", color=0xff0000)
-                    await ctx.send(embed=embed)
-                    return await message.delete()
+                embed = discord.Embed(title="Compilation failed!", description=f"Compiler output:\n{box(escape(compile_log, mass_mentions=True, formatting=True))}", color=0xff0000)
+                content = "Maybe you meant to use \\`\\`\\` instead of \\`?" if tiny_output else None
+                await ctx.send(content=content, embed=embed)
+                return await message.delete()
             elif int(warnings.group(1)) > 0:
                 embed = discord.Embed(title="Warnings found during compilation", description=f"**Compiler Output:**\n{box(escape(compile_log, mass_mentions=True, formatting=True))}**Execution Output:**\n{box(escape(run_log, mass_mentions=True, formatting=True))}", color=0xffcc00)
                 await ctx.send(embed=embed)

--- a/dmcompile/dmcompile.py
+++ b/dmcompile/dmcompile.py
@@ -187,7 +187,7 @@ class DMCompile(BaseCog):
                     await ctx.send(output)
                     return await message.delete()
                 else:
-                    embed = discord.Embed(description=f"**Compiler Output:**\n{box(escape(compile_log, mass_mentions=True, formatting=True))}**Execution Output:**\n{box(escape(run_log, mass_mentions=True, formatting=True))}", color=0x00ff00)
+                    embed = discord.Embed(description=f"**Execution Output:**\n{box(escape(run_log, mass_mentions=True, formatting=True))}", color=0x00ff00)
                     await ctx.send(embed=embed)
                     return await message.delete()
 

--- a/dmcompile/dmcompile.py
+++ b/dmcompile/dmcompile.py
@@ -96,7 +96,7 @@ class DMCompile(BaseCog):
         ```
         You can also do [p]compile `expression` to evaluate and print an expression. Example [p]compile `NORTH | EAST`.
 
-        You can include the target BYOND version before the code block. Example: [p]compile 514.1549 `world.byond_build`
+        You can include the target BYOND version before the code block. Example: [p]compile 514.1589 `world.byond_build`
         """
         tiny_output = False
 

--- a/dmcompile/dmcompile.py
+++ b/dmcompile/dmcompile.py
@@ -47,7 +47,7 @@ class DMCompile(BaseCog):
         pass
 
     @setcompile.command()
-    async def listener(self, ctx, url:str = None):
+    async def listener(self, ctx, url:str):
         """
         Set the full URL for the listener
 


### PR DESCRIPTION
ased on discussion in the OpenDream Discord here the changes from our fork. Accompanies https://github.com/BeeStation/dmcompile-listener/pull/1

- compile command with single backticks now evalutes an expression and returns it concisely using json_encode
![image](https://github.com/Crossedfall/crossed-cogs/assets/358431/262a24c8-cd14-4e55-abc6-2f6287f936eb)
- bot owner can set default version
- removes listbyond command as the dmcompile-listener PR lets people use any version
- I think titles in embeds are bold because I liked that look better
- maybe something else I forgot 

Let me know if any of this sucks or you don't want it and I'll remove it from the PR.