### PR TITLE
Ensure expiry is reset on each loop of the ban test

### DIFF
--- a/cclookup/cclookup.py
+++ b/cclookup/cclookup.py
@@ -59,22 +59,26 @@ class CCLookup(BaseCog):
                     total = 0
                     temp_embeds = []
                     embeds = []
-                    expires = "Permanent"
+                    expiresstr = "Permanent"
                     status = "Active"
 
                     for ban in bans:
                         total += 1
                         if "expires" in ban:
-                            expires = ban["expires"][:-10]
+                            expires = True
+                            expiresstr = ban["expires"][:-10]
+                        else:
+                            expires = False
+                            expires = "Permanent"
                         if not ban["active"]:
                             if "unbannedBy" in ban.keys():
                                 status = "Unbanned"
-                            elif expires and datetime.strptime(expires, "%Y-%m-%d").date() < datetime.now().date():
+                            elif expires and datetime.strptime(expiresstr, "%Y-%m-%d").date() < datetime.now().date():
                                 status = "Expired"
                             else:
                                 status = "Inactive"
                         bans_list += (
-                            f"\n[Banned On: {ban['bannedOn'][:-10]} - Expires: {expires} - {status}]\n"
+                            f"\n[Banned On: {ban['bannedOn'][:-10]} - Expires: {expiresstr} - {status}]\n"
                             f"{ban['reason']}\n"
                             f"{ban['type']} banned by {ban['bannedBy']} from {ban['sourceName']} ({ban['sourceRoleplayLevel']} RP)\n"
                             "-----"

--- a/cclookup/cclookup.py
+++ b/cclookup/cclookup.py
@@ -69,7 +69,8 @@ class CCLookup(BaseCog):
                             expiresstr = ban["expires"][:-10]
                         else:
                             expires = False
-                            expires = "Permanent"
+                            expiresstr = "Permanent"
+                            status = "Active"
                         if not ban["active"]:
                             if "unbannedBy" in ban.keys():
                                 status = "Unbanned"

--- a/cclookup/cclookup.py
+++ b/cclookup/cclookup.py
@@ -59,6 +59,7 @@ class CCLookup(BaseCog):
                     total = 0
                     temp_embeds = []
                     embeds = []
+                    expires = False
                     expiresstr = "Permanent"
                     status = "Active"
 


### PR DESCRIPTION
Otherwise bans that are active and do not have an expiry (like a perma) will inherit the expiry of the ban before them.